### PR TITLE
Add relativeTime Fn

### DIFF
--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -1,7 +1,6 @@
 import type { Owner } from "../types/github";
 
 export interface RepoCardProps {
-  id: number;
   full_name: string;
   description: string | null;
   owner?: Owner;

--- a/src/components/ResultList.tsx
+++ b/src/components/ResultList.tsx
@@ -1,5 +1,11 @@
 import { useRepoSearch } from "../hooks/useRepoSearch";
 import { useUrlSearchState } from "../hooks/useUrlSearchState";
+import { RepoCard } from "./RepoCard";
+import { relativeTime } from "../utils/relativeTime";
+
+// testing ---
+import type { RepoCardProps } from "./RepoCard";
+// ---
 
 const ResultList: React.FC = () => {
   const { q, page, per_page, sort } = useUrlSearchState();
@@ -12,6 +18,22 @@ const ResultList: React.FC = () => {
   if (data && data.items.length === 0) {
     return <p>No repositories found for "{q}"</p>;
   }
+  console.log("adora data: ", data);
+
+  const testingData: RepoCardProps = {
+    id: 10270250,
+    full_name: "facebook/react",
+    description: "The library for web and native user interfaces.",
+    owner: {
+      avatar_url: "https://avatars.githubusercontent.com/u/69631?v=4",
+    },
+    html_url: "https://github.com/facebook/react",
+    updated_at: "2026-04-30T16:42:54Z",
+    stargazers_count: 244772,
+    language: "JavaScript",
+  };
+
+  const formattedRelativeTime = relativeTime(testingData.updated_at);
 
   return (
     <>
@@ -25,6 +47,17 @@ const ResultList: React.FC = () => {
           );
         })}
       </ul>
+
+      <hr />
+      <RepoCard
+        full_name={testingData.full_name}
+        description={testingData.description}
+        owner={testingData.owner}
+        html_url={testingData.html_url}
+        stargazers_count={testingData.stargazers_count}
+        language={testingData.language}
+        updated_at={formattedRelativeTime}
+      />
     </>
   );
 };

--- a/src/utils/relativeTime.test.ts
+++ b/src/utils/relativeTime.test.ts
@@ -1,14 +1,65 @@
 import { describe, expect, it } from "vitest";
+import { relativeTime } from "./relativeTime";
 
-// the lowest is 1min
-// within 1 hour, show mins
-// at 1 hour, show 1 hour
-// Within 24 hours, show hours
-// at 24 hours, show 1 day
-// within a week (7 days), show days
-// at 7days, show the date
+describe("relativeTimeFn", () => {
+  const DATE_NOW = 1777975200000; // 2026-05-05T10:00:00Z
+  const TEST_CASES = [
+    // lowest boundary: exactly 1 minute
+    // diff: 30s
+    {
+      dateNow: DATE_NOW,
+      updatedAtTime: "2026-05-05T09:59:30Z",
+      output: "1 minute",
+    },
+    // within 1 hour: show minutes
+    // diff: 3540s (59mins)
+    {
+      dateNow: DATE_NOW,
+      updatedAtTime: "2026-05-05T09:01:00Z",
+      output: "59 minutes",
+    },
+    // at exactly 1 hour: show hours
+    {
+      dateNow: DATE_NOW,
+      updatedAtTime: "2026-05-05T09:00:00Z",
+      output: "1 hour",
+    },
+    // within 24 hours: show hours
+    // diff: 6 hrs 52 mins
+    {
+      dateNow: DATE_NOW,
+      updatedAtTime: "2026-05-05T03:07:14.036Z",
+      output: "6 hours",
+    },
+    // at exactly 24 hours: show days
+    {
+      dateNow: DATE_NOW,
+      updatedAtTime: "2026-05-04T10:00:00Z",
+      output: "1 day",
+    },
+    // within 7 days: show days
+    {
+      dateNow: DATE_NOW,
+      updatedAtTime: "2026-05-01T10:00:00Z",
+      output: "4 days",
+    },
+    // at 7 days: show formatted date
+    {
+      dateNow: DATE_NOW,
+      updatedAtTime: "2026-04-28T10:00:00Z",
+      output: "28 April 2026",
+    },
+    // well beyond 7 days
+    {
+      dateNow: DATE_NOW,
+      updatedAtTime: "2025-04-30T16:42:54Z",
+      output: "1 May 2025",
+    },
+  ];
 
-// diff = today - updated_at
-// if (diff >= 7 days) show the date
-
-describe("relativeTimeFn", () => {});
+  TEST_CASES.forEach(({ dateNow, updatedAtTime, output }) => {
+    it(`returns ${output} when given ${updatedAtTime}`, () => {
+      expect(relativeTime(dateNow, updatedAtTime)).toBe(output);
+    });
+  });
+});

--- a/src/utils/relativeTime.test.ts
+++ b/src/utils/relativeTime.test.ts
@@ -11,6 +11,12 @@ describe("relativeTimeFn", () => {
       updatedAtTime: "2026-05-05T09:59:30Z",
       output: "1 minute",
     },
+    // exact 1 min
+    {
+      dateNow: DATE_NOW,
+      updatedAtTime: "2026-05-05T09:59:00Z",
+      output: "1 minute",
+    },
     // within 1 hour: show minutes
     // diff: 3540s (59mins)
     {

--- a/src/utils/relativeTime.test.ts
+++ b/src/utils/relativeTime.test.ts
@@ -55,6 +55,11 @@ describe("relativeTimeFn", () => {
       updatedAtTime: "2025-04-30T16:42:54Z",
       output: "1 May 2025",
     },
+    {
+      dateNow: DATE_NOW,
+      updatedAtTime: "2026-05-05T11:00:00Z", // 1 hour in the future
+      output: "Repo is updated in the future time.",
+    },
   ];
 
   TEST_CASES.forEach(({ dateNow, updatedAtTime, output }) => {

--- a/src/utils/relativeTime.test.ts
+++ b/src/utils/relativeTime.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+// the lowest is 1min
+// within 1 hour, show mins
+// at 1 hour, show 1 hour
+// Within 24 hours, show hours
+// at 24 hours, show 1 day
+// within a week (7 days), show days
+// at 7days, show the date
+
+// diff = today - updated_at
+// if (diff >= 7 days) show the date
+
+describe("relativeTimeFn", () => {});

--- a/src/utils/relativeTime.ts
+++ b/src/utils/relativeTime.ts
@@ -1,10 +1,49 @@
-export const relativeTime = (dateTime: string): string => {
-  // turn it to Date instance
-  const date = new Date(dateTime);
+export function relativeTime(dateNow: number, updatedAtTime: string): string {
+  // find out the diff in epoch ms
+  const updatedAtDateEpochMs = Date.parse(updatedAtTime);
+  const diff = dateNow - updatedAtDateEpochMs;
 
-  return date.toLocaleDateString("en-AU", {
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
-};
+  // convert diff into days, hours, mins object
+  const diffObj = convertMs(diff);
+
+  console.log("diff: ", diff);
+  console.log("diffObj: ", diffObj);
+
+  // if more than 7 days, just returns the date itself
+  if (diffObj.days >= 7)
+    return new Date(updatedAtTime).toLocaleDateString("en-AU", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    });
+
+  // otherwise, returns the days/hours/mins
+  return convertPlaceholder(diffObj);
+}
+
+function convertMs(ms: number): Record<string, number> {
+  const days = Math.floor(ms / (24 * 60 * 60 * 1000));
+  const hours = Math.floor((ms % (24 * 60 * 60 * 1000)) / (60 * 60 * 1000));
+  const minutes = Math.floor((ms % (60 * 60 * 1000)) / (60 * 1000));
+
+  return { days, hours, minutes };
+}
+
+function convertPlaceholder(diffObject: Record<string, number>): string {
+  if (
+    diffObject.days === 0 &&
+    diffObject.hours === 0 &&
+    diffObject.minutes > 0
+  ) {
+    const label = diffObject.minutes === 1 ? "minute" : "minutes";
+    return `${diffObject.minutes} ${label}`;
+  } else if (diffObject.days === 0 && diffObject.hours > 0) {
+    const label = diffObject.hours === 1 ? "hour" : "hours";
+    return `${diffObject.hours} ${label}`;
+  } else if (diffObject.days > 0) {
+    const label = diffObject.days === 1 ? "day" : "days";
+    return `${diffObject.days} ${label}`;
+  } else {
+    return "1 minute";
+  }
+}

--- a/src/utils/relativeTime.ts
+++ b/src/utils/relativeTime.ts
@@ -33,6 +33,11 @@ function convertMs(ms: number): TimeDiff {
 }
 
 function convertPlaceholder(diffObject: TimeDiff): string {
+  // Guard against negatiev diff
+  if (diffObject.days < 0 || diffObject.hours < 0 || diffObject.minutes < 0) {
+    return "Repo is updated in the future time.";
+  }
+
   if (
     diffObject.days === 0 &&
     diffObject.hours === 0 &&

--- a/src/utils/relativeTime.ts
+++ b/src/utils/relativeTime.ts
@@ -1,0 +1,10 @@
+export const relativeTime = (dateTime: string): string => {
+  // turn it to Date instance
+  const date = new Date(dateTime);
+
+  return date.toLocaleDateString("en-AU", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+};

--- a/src/utils/relativeTime.ts
+++ b/src/utils/relativeTime.ts
@@ -1,3 +1,9 @@
+interface TimeDiff {
+  days: number;
+  hours: number;
+  minutes: number;
+}
+
 export function relativeTime(dateNow: number, updatedAtTime: string): string {
   // find out the diff in epoch ms
   const updatedAtDateEpochMs = Date.parse(updatedAtTime);
@@ -5,9 +11,6 @@ export function relativeTime(dateNow: number, updatedAtTime: string): string {
 
   // convert diff into days, hours, mins object
   const diffObj = convertMs(diff);
-
-  console.log("diff: ", diff);
-  console.log("diffObj: ", diffObj);
 
   // if more than 7 days, just returns the date itself
   if (diffObj.days >= 7)
@@ -21,7 +24,7 @@ export function relativeTime(dateNow: number, updatedAtTime: string): string {
   return convertPlaceholder(diffObj);
 }
 
-function convertMs(ms: number): Record<string, number> {
+function convertMs(ms: number): TimeDiff {
   const days = Math.floor(ms / (24 * 60 * 60 * 1000));
   const hours = Math.floor((ms % (24 * 60 * 60 * 1000)) / (60 * 60 * 1000));
   const minutes = Math.floor((ms % (60 * 60 * 1000)) / (60 * 1000));
@@ -29,7 +32,7 @@ function convertMs(ms: number): Record<string, number> {
   return { days, hours, minutes };
 }
 
-function convertPlaceholder(diffObject: Record<string, number>): string {
+function convertPlaceholder(diffObject: TimeDiff): string {
   if (
     diffObject.days === 0 &&
     diffObject.hours === 0 &&

--- a/src/utils/relativeTime.ts
+++ b/src/utils/relativeTime.ts
@@ -9,6 +9,11 @@ export function relativeTime(dateNow: number, updatedAtTime: string): string {
   const updatedAtDateEpochMs = Date.parse(updatedAtTime);
   const diff = dateNow - updatedAtDateEpochMs;
 
+  // Guard against negative diff and early return
+  if (diff < 0) {
+    return "Repo is updated in the future time.";
+  }
+
   // convert diff into days, hours, mins object
   const diffObj = convertMs(diff);
 
@@ -33,11 +38,6 @@ function convertMs(ms: number): TimeDiff {
 }
 
 function convertPlaceholder(diffObject: TimeDiff): string {
-  // Guard against negatiev diff
-  if (diffObject.days < 0 || diffObject.hours < 0 || diffObject.minutes < 0) {
-    return "Repo is updated in the future time.";
-  }
-
   if (
     diffObject.days === 0 &&
     diffObject.hours === 0 &&


### PR DESCRIPTION
# Context 

Part of issue #3 

# Changes

- Add `relativeTime` function to find out the time difference between the repo's `updated_at` time and now.
- If the diff comes back as negative (unlikely but this is defensive programming), render "Repo is updated in the future time."
- Convert the difference to days, hours, mins:
  - The lowest is 1 min
  - within 1 hour, the `relativeTime` fn should show mins.
  - at 1 hour, the `relativeTime` fn should show 1 hour.
  - Within 24 hours, the `relativeTime` fn should show hours.
  - at 24 hours, the `relativeTime` fn should show 1 day.
  - within a week (7 days), the `relativeTime` fn should show days.
  - at 7days, the `relativeTime` fn should show the date.
 - Add test too.
 
 
 I enjoyed doing this PR without any AI assistance 😍