### PR TITLE
Create formatCompactNumber Fn

### DIFF
--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -1,4 +1,5 @@
 import type { Owner } from "../types/github";
+import { formatCompactNumber } from "../utils/formatCompactNumber";
 
 export interface RepoCardProps {
   full_name: string;
@@ -19,6 +20,8 @@ export const RepoCard = ({
   language,
   updatedLabel,
 }: RepoCardProps) => {
+  const starsLabel = `${formatCompactNumber(stargazers_count)} ${stargazers_count === 1 ? "star" : "stars"}`;
+
   return (
     <>
       <div className="border-1 border-solid border-pink-300 rounded-md p-4">
@@ -52,7 +55,7 @@ export const RepoCard = ({
                 <span className="mx-2">.</span>
               </>
             )}
-            <li>{stargazers_count} stars</li>
+            <li>{starsLabel}</li>
             <span className="mx-2">.</span>
             <li>{updatedLabel}</li>
           </ul>

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -48,7 +48,7 @@ export const RepoCard = ({
 
         {/* Footer */}
         <div className="mt-2">
-          <ul className="flex text-gray-500 text-sm">
+          <ul className="flex text-gray-500 text-sm items-center flex-wrap">
             {language && (
               <>
                 <li>{language}</li>

--- a/src/utils/formatCompactNumber.test.ts
+++ b/src/utils/formatCompactNumber.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { formatCompactNumber } from "./formatCompactNumber";
+
+describe("formatCompactNumber Fn", () => {
+  const TEST_CASES = [
+    {
+      input: 0,
+      output: "0",
+    },
+    {
+      input: 1,
+      output: "1",
+    },
+    {
+      input: 999,
+      output: "999",
+    },
+    {
+      input: 1000,
+      output: "1K",
+    },
+    {
+      input: 9999,
+      output: "10K",
+    },
+    {
+      input: 10_000,
+      output: "10K",
+    },
+    {
+      input: 10_038,
+      output: "10K",
+    },
+    {
+      input: 100_000,
+      output: "100K",
+    },
+    {
+      input: 244_712,
+      output: "244.7K",
+    },
+    {
+      input: 999_999,
+      output: "1M",
+    },
+    {
+      input: 1_000_000,
+      output: "1M",
+    },
+    {
+      input: 999_999_999,
+      output: "1B",
+    },
+    {
+      input: 1_000_000_000,
+      output: "1B",
+    },
+    {
+      input: 999_999_999_999,
+      output: "1T",
+    },
+    {
+      input: 1_000_000_000_000,
+      output: "1T",
+    },
+    {
+      input: 999_999_999_999_999,
+      output: "1000T",
+    },
+    {
+      input: Infinity,
+      output: "∞",
+    },
+  ];
+
+  TEST_CASES.forEach(({ input, output }) => {
+    it(`returns ${output} when given ${input}`, () => {
+      expect(formatCompactNumber(input)).toEqual(output);
+    });
+  });
+});

--- a/src/utils/formatCompactNumber.ts
+++ b/src/utils/formatCompactNumber.ts
@@ -1,60 +1,7 @@
-// Below 999 -> 999
-
-// 1000 -> 1k
-// 1265 -> 1.2k
-// 10000 -> 10k
-// 18765 -> 18.7k
-// 100000 -> 100k
-// 244772 -> 244k
-
-// 1,000,000 -> 1m
-// 1,673,893 -> 1.6m
-
-// 1,000,000,000 -> 1b
-// 2,397,397,777 -> 2.3b
-
 export function formatCompactNumber(stars: number): string {
-  if (stars <= 999) return stars.toString();
-
-  if (stars >= 1_000 && stars <= 999_999) {
-    if (Number.isInteger(stars / 1_000)) {
-      return `${stars / 1_000}k`;
-    } else {
-      return (stars / 1_000)
-        .toString()
-        .replace(/(^\d+)(.)(\d)(\d+)/, "$1$2$3k");
-    }
-  }
-
-  if (stars >= 1_000_000 && stars <= 999_999_999) {
-    if (Number.isInteger(stars / 1_000_000)) {
-      return `${stars / 1_000_000}m`;
-    } else {
-      return (stars / 1_000_000)
-        .toString()
-        .replace(/(^\d+)(.)(\d)(\d+)/, "$1$2$3m");
-    }
-  }
-
-  if (stars >= 1_000_000_000 && stars <= 999_999_999_999) {
-    if (Number.isInteger(stars / 1_000_000_000)) {
-      return `${stars / 1_000_000_000}b`;
-    } else {
-      return (stars / 1_000_000_000)
-        .toString()
-        .replace(/(^\d+)(.)(\d)(\d+)/, "$1$2$3b");
-    }
-  }
-
-  if (stars >= 1_000_000_000_000 && stars <= 999_999_999_999_999) {
-    if (Number.isInteger(stars / 1_000_000_000_000)) {
-      return `${stars / 1_000_000_000_000}t`;
-    } else {
-      return (stars / 1_000_000_000_000)
-        .toString()
-        .replace(/(^\d+)(.)(\d)(\d+)/, "$1$2$3t");
-    }
-  }
-
-  return "Infinity";
+  const formatter = new Intl.NumberFormat("en", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  });
+  return formatter.format(stars);
 }

--- a/src/utils/formatCompactNumber.ts
+++ b/src/utils/formatCompactNumber.ts
@@ -1,0 +1,60 @@
+// Below 999 -> 999
+
+// 1000 -> 1k
+// 1265 -> 1.2k
+// 10000 -> 10k
+// 18765 -> 18.7k
+// 100000 -> 100k
+// 244772 -> 244k
+
+// 1,000,000 -> 1m
+// 1,673,893 -> 1.6m
+
+// 1,000,000,000 -> 1b
+// 2,397,397,777 -> 2.3b
+
+export function formatCompactNumber(stars: number): string {
+  if (stars <= 999) return stars.toString();
+
+  if (stars >= 1_000 && stars <= 999_999) {
+    if (Number.isInteger(stars / 1_000)) {
+      return `${stars / 1_000}k`;
+    } else {
+      return (stars / 1_000)
+        .toString()
+        .replace(/(^\d+)(.)(\d)(\d+)/, "$1$2$3k");
+    }
+  }
+
+  if (stars >= 1_000_000 && stars <= 999_999_999) {
+    if (Number.isInteger(stars / 1_000_000)) {
+      return `${stars / 1_000_000}m`;
+    } else {
+      return (stars / 1_000_000)
+        .toString()
+        .replace(/(^\d+)(.)(\d)(\d+)/, "$1$2$3m");
+    }
+  }
+
+  if (stars >= 1_000_000_000 && stars <= 999_999_999_999) {
+    if (Number.isInteger(stars / 1_000_000_000)) {
+      return `${stars / 1_000_000_000}b`;
+    } else {
+      return (stars / 1_000_000_000)
+        .toString()
+        .replace(/(^\d+)(.)(\d)(\d+)/, "$1$2$3b");
+    }
+  }
+
+  if (stars >= 1_000_000_000_000 && stars <= 999_999_999_999_999) {
+    if (Number.isInteger(stars / 1_000_000_000_000)) {
+      return `${stars / 1_000_000_000_000}t`;
+    } else {
+      return (stars / 1_000_000_000_000)
+        .toString()
+        .replace(/(^\d+)(.)(\d)(\d+)/, "$1$2$3t");
+    }
+  }
+
+  return "Infinity";
+}


### PR DESCRIPTION
# Context

Resolves issue #3 

# Screenshot

| Big Screen | Small Screen |
| ------ | ------ |
| <img width="721" height="1254" alt="image" src="https://github.com/user-attachments/assets/6edad182-7bd5-47ac-978e-1963b28785ec" /> | <img width="398" height="766" alt="image" src="https://github.com/user-attachments/assets/10507b2f-d7b1-48bc-8366-34246de84562" /> |



# Changes

- Add `formatCompactNumber` fn to format the stars count, like Github by using `Intl.NumberFormat` API, so the "k" will be "K", in upper case.
- Add some styling to RepoCard footer part so it looks nice in small screen.